### PR TITLE
feat: daily poem site (vercel + api)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
-# test-codex
+# Poème du jour — #tendances
+Déployable sur **Vercel**.  
+- API: `/api/poem` (génère le poème du jour via OpenAI)  
+- Page: `/` (affiche le poème)
 
-Ce dépôt contient un simple projet Node.js utilisé pour des tests.
+## Variables d'environnement
+- `OPENAI_API_KEY` (obligatoire)
+- `OPENAI_MODEL` (optionnel, défaut: gpt-4o-mini)
+
+## Déploiement
+1. Connecter le repo à Vercel.
+2. Ajouter `OPENAI_API_KEY` dans Project → Settings → Environment Variables.
+3. Déployer → ouvrir l'URL.

--- a/api/poem.js
+++ b/api/poem.js
@@ -1,0 +1,46 @@
+// /api/poem.js — Fonction serverless Vercel
+import OpenAI from "openai";
+
+// --- 1) Récupération de hashtags (placeholder à remplacer par TikTok plus tard)
+function getTrendingHashtagsFallback() {
+  // Remplace plus tard par un fetch vers une source "tendances" (ou TikTok via un service tiers).
+  const pools = [
+    ["#AI", "#poetry", "#aesthetic"],
+    ["#mondaymotivation", "#sunset", "#urban"],
+    ["#fall", "#cozy", "#coffee"],
+    ["#music", "#cinema", "#dance"],
+  ];
+  return pools[Math.floor((new Date().getTime() / 86400000) % pools.length)];
+}
+
+// --- 2) Générer un poème à partir des hashtags
+async function generatePoem(hashtags) {
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const prompt = `
+  Écris un poème libre de 12 à 20 vers, sans rimes systématiques, nerveux et imagé,
+  à partir de ces hashtags du jour: ${hashtags.join(" ")}.
+  Style: Vodakien, synesthésique, mélange sublime/grotesque, évite les clichés.
+  Interdis-toi de répéter les hashtags tels quels plus d'une fois; intègre-les sémantiquement.
+  `;
+  // modèle par défaut (changeable par variable d’env.)
+  const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
+  const res = await client.chat.completions.create({
+    model,
+    messages: [{ role: "user", content: prompt }],
+    temperature: 0.95,
+  });
+  return res.choices[0]?.message?.content?.trim() || "…";
+}
+
+export default async function handler(req, res) {
+  try {
+    const today = new Date();
+    const date = today.toLocaleDateString("fr-FR", { weekday: "long", year: "numeric", month: "long", day: "numeric" });
+    const hashtags = getTrendingHashtagsFallback();
+    const poem = await generatePoem(hashtags);
+    res.status(200).json({ date, hashtags, poem });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "poem_generation_failed" });
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Poème du jour — #tendances</title>
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <main class="wrap">
+    <h1>Poème du jour</h1>
+    <p class="date" id="date"></p>
+    <pre id="poem">Chargement…</pre>
+    <p class="hashtags" id="tags"></p>
+  </main>
+  <script>
+  (async () => {
+    const r = await fetch('/api/poem');
+    const data = await r.json();
+    document.getElementById('date').textContent = data.date;
+    document.getElementById('poem').textContent = data.poem;
+    document.getElementById('tags').textContent = 'Hashtags: ' + data.hashtags.join(' ');
+  })();
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,16 @@
 {
-  "name": "test-codex",
+  "name": "daily-poem",
   "version": "1.0.0",
-  "main": "index.js",
-  "license": "MIT"
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node api/poem.js",
+    "format": "prettier -w ."
+  },
+  "dependencies": {
+    "openai": "^4.57.0"
+  },
+  "devDependencies": {
+    "prettier": "^3.3.3"
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,6 @@
+:root { font-family: ui-serif, Georgia, serif; background:#0e0e10; color:#eaeaea; }
+.wrap { max-width: 720px; margin: 6rem auto; padding: 0 1rem; }
+h1 { font-size: clamp(2rem, 3vw, 3rem); margin: 0 0 0.5rem; }
+.date { opacity:.7; margin: 0 0 2rem; }
+pre { white-space: pre-wrap; line-height: 1.6; font-size: 1.15rem; }
+.hashtags { margin-top: 1rem; opacity:.8; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "cleanUrls": true,
+  "rewrites": [{ "source": "/api/poem", "destination": "/api/poem.js" }]
+}


### PR DESCRIPTION
## Summary
- add a static front-end page to render the poem of the day with trending hashtags
- implement a Vercel serverless function that generates poems with OpenAI
- update project metadata and docs for Vercel deployment and environment setup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da643182448322af91aee62da206ec