### PR TITLE
Add daily poem KV storage and cron generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # Poème du jour — #tendances
-Déployable sur **Vercel**.  
-- API: `/api/poem` (génère le poème du jour via OpenAI)  
-- Page: `/` (affiche le poème)
+Déployable sur **Vercel**.
+
+- API publique: `/api/today`  (lit KV)
+- Cron Vercel: `/api/cron-generate`  (protégé; génère 1×/jour à 13:00 UTC)
+- Stockage: Vercel KV, clé `poem:YYYY-MM-DD`
 
 ## Variables d'environnement
 - `OPENAI_API_KEY` (obligatoire)
 - `OPENAI_MODEL` (optionnel, défaut: gpt-4o-mini)
+- `CRON_SECRET` (pour sécuriser `/api/cron-generate`)
 
 ## Déploiement
 1. Connecter le repo à Vercel.
-2. Ajouter `OPENAI_API_KEY` dans Project → Settings → Environment Variables.
+2. Ajouter `OPENAI_API_KEY`, `CRON_SECRET` (et `OPENAI_MODEL` si besoin) dans Project → Settings → Environment Variables.
 3. Déployer → ouvrir l'URL.

--- a/api/cron-generate.js
+++ b/api/cron-generate.js
@@ -1,0 +1,59 @@
+import OpenAI from "openai";
+import { kv } from "@vercel/kv";
+
+// 1) Source hashtags : stub remplaçable
+async function getTrendingHashtags() {
+  // TODO: remplacer par une vraie source “tendances TikTok”.
+  const pools = [
+    ["#tendance", "#poesie", "#ville", "#lumiere", "#nuit"],
+    ["#musique", "#danse", "#cinema", "#foule", "#ecran"],
+    ["#pluie", "#metro", "#neon", "#histoire", "#instant"],
+    ["#cafe", "#lecture", "#automne", "#rue", "#souvenir"],
+  ];
+  return pools[Math.floor((Date.now() / 86400000) % pools.length)];
+}
+
+async function generatePoem(hashtags) {
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const prompt = `
+  Écris un poème libre (12 à 20 vers), évocateur et imagé, sans rimes systématiques.
+  Inspire-toi de ces hashtags/mots du jour : ${hashtags.join(" ")}.
+  Évite les clichés ; intègre les mots de façon sémantique, sans les répéter littéralement plus d'une fois.
+  `;
+  const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
+  const r = await client.chat.completions.create({
+    model,
+    messages: [{ role: "user", content: prompt }],
+    temperature: 0.95,
+  });
+  return r.choices[0]?.message?.content?.trim() || "…";
+}
+
+export default async function handler(req, res) {
+  // Sécurise l’appel (Vercel Cron enverra l’en-tête)
+  const auth = req.headers["x-cron-secret"];
+  if (!process.env.CRON_SECRET || auth !== process.env.CRON_SECRET) {
+    return res.status(401).json({ error: "unauthorized" });
+  }
+
+  // Date du jour à Paris
+  const parisNow = new Date().toLocaleString("en-US", { timeZone: "Europe/Paris" });
+  const d = new Date(parisNow);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const key = `poem:${yyyy}-${mm}-${dd}`;
+
+  // Si déjà généré, ne rien faire
+  const exists = await kv.exists(key);
+  if (exists) return res.status(200).json({ status: "exists" });
+
+  const hashtags = await getTrendingHashtags();
+  const poem = await generatePoem(hashtags);
+  const dateLabel = d.toLocaleDateString("fr-FR", { weekday: "long", year: "numeric", month: "long", day: "numeric" });
+
+  const record = { date: dateLabel, hashtags, poem, generatedAt: new Date().toISOString() };
+  await kv.set(key, record, { ex: 60 * 60 * 24 * 3 }); // expire après 3 jours (sécurité)
+
+  res.status(200).json({ status: "created", key, hashtagsCount: hashtags.length });
+}

--- a/api/today.js
+++ b/api/today.js
@@ -1,0 +1,14 @@
+import { kv } from "@vercel/kv";
+
+export default async function handler(req, res) {
+  const parisNow = new Date().toLocaleString("en-US", { timeZone: "Europe/Paris" });
+  const d = new Date(parisNow);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const key = `poem:${yyyy}-${mm}-${dd}`;
+
+  const record = await kv.get(key);
+  if (!record) return res.status(404).json({ error: "not_ready", message: "Poème pas encore généré aujourd’hui." });
+  res.status(200).json(record);
+}

--- a/index.html
+++ b/index.html
@@ -1,26 +1,13 @@
-<!doctype html>
-<html lang="fr">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Poème du jour — #tendances</title>
-  <link rel="stylesheet" href="/styles.css" />
-</head>
-<body>
-  <main class="wrap">
-    <h1>Poème du jour</h1>
-    <p class="date" id="date"></p>
-    <pre id="poem">Chargement…</pre>
-    <p class="hashtags" id="tags"></p>
-  </main>
-  <script>
-  (async () => {
-    const r = await fetch('/api/poem');
-    const data = await r.json();
-    document.getElementById('date').textContent = data.date;
-    document.getElementById('poem').textContent = data.poem;
-    document.getElementById('tags').textContent = 'Hashtags: ' + data.hashtags.join(' ');
-  })();
-  </script>
-</body>
-</html>
+<!doctype html><html lang="fr"><head>
+<meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Poème du jour</title><link rel="stylesheet" href="/styles.css"/>
+</head><body><main class="wrap">
+<h1>Poème du jour</h1><p class="date" id="date"></p><pre id="poem">Chargement…</pre><p class="hashtags" id="tags"></p>
+</main><script>
+(async()=>{try{
+  const r=await fetch('/api/today'); const data=await r.json();
+  if(!r.ok) throw new Error(data?.message||'not ready');
+  date.textContent=data.date; poem.textContent=data.poem; tags.textContent='Hashtags: '+data.hashtags.join(' ');
+}catch(e){poem.textContent="Le poème du jour n'est pas encore prêt. Reviens plus tard.";}})
+();
+</script></body></html>

--- a/package.json
+++ b/package.json
@@ -4,13 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node api/poem.js",
     "format": "prettier -w ."
   },
   "dependencies": {
-    "openai": "^4.57.0"
+    "openai": "^4.57.0",
+    "@vercel/kv": "^1.0.1"
   },
-  "devDependencies": {
-    "prettier": "^3.3.3"
-  }
+  "devDependencies": { "prettier": "^3.3.3" }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,11 @@
 {
   "cleanUrls": true,
-  "rewrites": [{ "source": "/api/poem", "destination": "/api/poem.js" }]
+  "rewrites": [
+    { "source": "/api/poem", "destination": "/api/today.js" },
+    { "source": "/api/today", "destination": "/api/today.js" },
+    { "source": "/api/cron-generate", "destination": "/api/cron-generate.js" }
+  ],
+  "crons": [
+    { "path": "/api/cron-generate", "schedule": "0 13 * * *" }
+  ]
 }


### PR DESCRIPTION
## Summary
- add a KV-backed `/api/today` endpoint to serve the poem of the day
- implement a cron-protected generator that stores poems in Vercel KV
- update the frontend, configuration, and docs to call the new endpoint and schedule the cron

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da6dbd92d483228ac589b2220a2069