### PR TITLE
Add Upstash Redis client initialization

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,0 +1,29 @@
+import { Redis } from "@upstash/redis";
+
+const url = process.env.STORAGE_KV_REST_API_URL;
+const token = process.env.STORAGE_KV_REST_API_TOKEN;
+
+if (!url) {
+  throw new Error("Missing STORAGE_KV_REST_API_URL environment variable");
+}
+
+if (!token) {
+  throw new Error("Missing STORAGE_KV_REST_API_TOKEN environment variable");
+}
+
+const globalKey = Symbol.for("daily-poem.redis");
+const globalSymbols = Object.getOwnPropertySymbols(globalThis);
+
+let redisClient = globalSymbols.includes(globalKey)
+  ? globalThis[globalKey]
+  : null;
+
+if (!redisClient) {
+  redisClient = new Redis({
+    url,
+    token,
+  });
+  globalThis[globalKey] = redisClient;
+}
+
+export default redisClient;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "openai": "^4.57.0",
-    "@vercel/kv": "^1.0.1"
+    "@vercel/kv": "^1.0.1",
+    "@upstash/redis": "^1.29.4"
   },
   "devDependencies": { "prettier": "^3.3.3" }
 }


### PR DESCRIPTION
## Summary
- add @upstash/redis dependency for Redis access
- create lib/redis.js to initialize and export a shared Redis client using env vars

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da742d6ac083228d9a296542ed1b55