### PR TITLE
Add test KV API route

### DIFF
--- a/api/test-kv.js
+++ b/api/test-kv.js
@@ -1,0 +1,13 @@
+import redis from "../lib/redis.js";
+
+export default async function handler(req, res) {
+  try {
+    await redis.set("test", "hello");
+    const value = await redis.get("test");
+
+    res.status(200).json({ key: "test", value });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "kv_test_failed" });
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `/api/test-kv` endpoint that writes and reads a test value using the shared Redis client

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da74e42d9c832297f50dba1ea31f78