### PR TITLE
Add Upstash KV test endpoint

### DIFF
--- a/api/test-kv.js
+++ b/api/test-kv.js
@@ -1,11 +1,16 @@
-import redis from "../lib/redis.js";
+import { Redis } from "@upstash/redis";
+
+const redis = new Redis({
+  url: process.env.KV_REST_API_URL,
+  token: process.env.KV_REST_API_TOKEN,
+});
 
 export default async function handler(req, res) {
   try {
-    await redis.set("test", "hello");
-    const value = await redis.get("test");
+    await redis.set("hello", "world");
+    const value = await redis.get("hello");
 
-    res.status(200).json({ key: "test", value });
+    res.status(200).json({ key: "hello", value });
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: "kv_test_failed" });


### PR DESCRIPTION
## Summary
- create an API route that uses the Upstash Redis client to set and retrieve a test value
- return the fetched value as JSON and send an error response if the KV call fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da772ee9c0832288268aa0a8d735da