### PR TITLE
Add method guard to test-kv endpoint

### DIFF
--- a/api/test-kv.js
+++ b/api/test-kv.js
@@ -6,6 +6,11 @@ const redis = new Redis({
 });
 
 export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", ["GET"]);
+    return res.status(405).json({ error: "method_not_allowed" });
+  }
+
   try {
     await redis.set("hello", "world");
     const value = await redis.get("hello");


### PR DESCRIPTION
## Summary
- reject non-GET requests for the /api/test-kv endpoint
- return a 405 response with the allow header when the method is not permitted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da77c1c2588322888c2160831d9c50