### PR TITLE
Update poem retrieval in today API

### DIFF
--- a/api/today.js
+++ b/api/today.js
@@ -1,24 +1,63 @@
 import { Redis } from "@upstash/redis";
 
 const redis = Redis.fromEnv();
+const KEY_PREFIX = "poem:";
+const PARIS_TZ = "Europe/Paris";
 
-function getParisDateKey() {
-  const date = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "Europe/Paris",
-  }).format(new Date());
-  return `poem:${date}`;
+function formatParisDate(date = new Date()) {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: PARIS_TZ,
+  }).format(date);
+}
+
+function buildKey(dateString) {
+  return `${KEY_PREFIX}${dateString}`;
+}
+
+function extractDateFromKey(key) {
+  if (typeof key === "string" && key.startsWith(KEY_PREFIX)) {
+    return key.slice(KEY_PREFIX.length);
+  }
+  return undefined;
+}
+
+function parseRecord(record) {
+  if (record == null) {
+    return null;
+  }
+
+  if (typeof record === "string") {
+    try {
+      return JSON.parse(record);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  if (typeof record === "object") {
+    return record;
+  }
+
+  return null;
 }
 
 export default async function handler(req, res) {
-  const todayKey = getParisDateKey();
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).end();
+  }
 
-  let record = await redis.get(todayKey);
+  const todayKey = buildKey(formatParisDate());
+  let targetKey = todayKey;
+
+  let record = parseRecord(await redis.get(targetKey));
 
   if (!record) {
-    const latestKey = await redis.get("poem:latest");
+    const latestPointer = await redis.get(`${KEY_PREFIX}latest`);
 
-    if (typeof latestKey === "string" && latestKey) {
-      record = await redis.get(latestKey);
+    if (typeof latestPointer === "string" && latestPointer) {
+      targetKey = latestPointer;
+      record = parseRecord(await redis.get(latestPointer));
     }
   }
 
@@ -26,13 +65,14 @@ export default async function handler(req, res) {
     return res.status(404).json({ error: "not_ready" });
   }
 
-  const { date, hashtags, poem, generatedAt } = record;
+  const dateFromRecord = typeof record.date === "string" ? record.date : undefined;
+  const date = dateFromRecord ?? extractDateFromKey(targetKey) ?? formatParisDate();
 
   return res.status(200).json({
     date,
-    hashtags,
-    poem,
-    generatedAt,
-    note: `Poème du ${date ?? todayKey.slice("poem:".length)} (affiché jusqu’à la prochaine génération)`
+    hashtags: record.hashtags,
+    poem: record.poem,
+    generatedAt: record.generatedAt,
+    note: `Poème du ${date} (affiché jusqu’à la prochaine génération)`,
   });
 }


### PR DESCRIPTION
## Summary
- ensure the /api/today endpoint only handles GET requests
- fetch the daily poem from Redis, falling back to the latest pointer if needed
- normalize the Redis payload and always include the display note in the response

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8e96926883228abb744bffb5fc4c