### PR TITLE
Add mock fallback handling to cron poem API

### DIFF
--- a/pages/api/cron-generate.ts
+++ b/pages/api/cron-generate.ts
@@ -7,14 +7,26 @@ const redis = Redis.fromEnv();
 const TTL_SECONDS = 60 * 60 * 48;
 const MODEL = "gpt-4o-mini";
 
+type PoemSource = "openai" | "mock";
+
 interface PoemPayload {
   date: string;
   poem: string;
   hashtags: string[];
+  source: PoemSource;
+}
+
+function buildMockPoem(): string {
+  return [
+    "Le serveur s'endort",
+    "La clé manque de crédit",
+    "Mais les mots survivent",
+    "Dans le vide simulé",
+  ].join("\n");
 }
 
 type CronResponse =
-  | { status: "ok"; date: string; poem: string }
+  | { status: "ok"; date: string; poem: string; source: PoemSource }
   | { error: string };
 
 export default async function handler(
@@ -42,9 +54,12 @@ export default async function handler(
     if (existing) {
       const parsed: PoemPayload =
         typeof existing === "string" ? JSON.parse(existing) : existing;
-      return res
-        .status(200)
-        .json({ status: "ok", date: parsed.date, poem: parsed.poem });
+      return res.status(200).json({
+        status: "ok",
+        date: parsed.date,
+        poem: parsed.poem,
+        source: parsed.source ?? "openai",
+      });
     }
 
     const apiKey = process.env.OPENAI_API_KEY;
@@ -57,54 +72,86 @@ export default async function handler(
 
     const prompt = `Tu es un poète francophone. Crée un poème original pour aujourd'hui accompagné de 3 hashtags tendance pertinents. Réponds en JSON avec les clés suivantes: poem (poème multi-lignes) et hashtags (tableau de chaînes).`;
 
-    const response = await openai.responses.create({
-      model: MODEL,
-      input: prompt,
-      response_format: {
-        type: "json_schema",
-        json_schema: {
-          name: "poem_of_the_day",
-          schema: {
-            type: "object",
-            properties: {
-              poem: { type: "string" },
-              hashtags: {
-                type: "array",
-                items: { type: "string" },
-                minItems: 1,
+    try {
+      const response = await openai.responses.create({
+        model: MODEL,
+        input: prompt,
+        response_format: {
+          type: "json_schema",
+          json_schema: {
+            name: "poem_of_the_day",
+            schema: {
+              type: "object",
+              properties: {
+                poem: { type: "string" },
+                hashtags: {
+                  type: "array",
+                  items: { type: "string" },
+                  minItems: 1,
+                },
               },
+              required: ["poem", "hashtags"],
+              additionalProperties: false,
             },
-            required: ["poem", "hashtags"],
-            additionalProperties: false,
           },
         },
-      },
-    });
+      });
 
-    const outputText = response.output_text;
+      const outputText = response.output_text;
 
-    let poemPayload: Omit<PoemPayload, "date"> & { date?: string };
-    try {
-      poemPayload = JSON.parse(outputText);
-    } catch (parseError) {
-      console.error("Erreur de parsing de la réponse OpenAI", parseError, outputText);
-      return res.status(502).json({ error: "Réponse invalide du modèle" });
+      let poemPayload: Omit<PoemPayload, "date" | "source"> & {
+        date?: string;
+        source?: PoemSource;
+      };
+      try {
+        poemPayload = JSON.parse(outputText);
+      } catch (parseError) {
+        throw new Error(
+          `Réponse OpenAI invalide: ${
+            parseError instanceof Error ? parseError.message : "erreur inconnue"
+          }`
+        );
+      }
+
+      if (!poemPayload.poem || !Array.isArray(poemPayload.hashtags)) {
+        throw new Error("Réponse OpenAI incomplète");
+      }
+
+      const payload: PoemPayload = {
+        date: today,
+        poem: poemPayload.poem,
+        hashtags: poemPayload.hashtags,
+        source: "openai",
+      };
+
+      await redis.set(key, JSON.stringify(payload), { ex: TTL_SECONDS });
+
+      return res.status(200).json({
+        status: "ok",
+        date: today,
+        poem: payload.poem,
+        source: payload.source,
+      });
+    } catch (apiError) {
+      console.error("Erreur OpenAI, bascule en mode mock", apiError);
+
+      const mockPoem = buildMockPoem();
+      const mockPayload: PoemPayload = {
+        date: today,
+        poem: mockPoem,
+        hashtags: ["#mockmode", "#poesie", "#fallback"],
+        source: "mock",
+      };
+
+      await redis.set(key, JSON.stringify(mockPayload), { ex: TTL_SECONDS });
+
+      return res.status(200).json({
+        status: "ok",
+        date: today,
+        poem: mockPoem,
+        source: "mock",
+      });
     }
-
-    if (!poemPayload.poem || !Array.isArray(poemPayload.hashtags)) {
-      console.error("Réponse OpenAI incomplète", poemPayload);
-      return res.status(502).json({ error: "Réponse invalide du modèle" });
-    }
-
-    const payload: PoemPayload = {
-      date: today,
-      poem: poemPayload.poem,
-      hashtags: poemPayload.hashtags,
-    };
-
-    await redis.set(key, JSON.stringify(payload), { ex: TTL_SECONDS });
-
-    return res.status(200).json({ status: "ok", date: today, poem: payload.poem });
   } catch (error) {
     console.error("Erreur dans /api/cron-generate", error);
     return res.status(500).json({ error: "Erreur interne" });


### PR DESCRIPTION
## Summary
- add a mock poem generator and source tracking to the cron poem API
- fall back to mock generation when OpenAI responses fail and persist the result to Redis
- include the poem source in successful API responses for both cached and new poems

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68da9310a9508322aa800577fde3b737