### PR TITLE
Add RSS topics script

### DIFF
--- a/scripts/rss-topics.js
+++ b/scripts/rss-topics.js
@@ -1,224 +1,137 @@
+// Dépendances à installer (si non déjà présentes) :
 // npm install rss-parser lodash
+//
+// scripts/rss-topics.js
+//
+// Simple connecteur RSS -> extraction de mots / scoring / catégorisation.
+// Contient une variable DEFAULT_FEEDS listant des flux prêts à l'emploi.
+// Usage : const { fetchRssTopics } = require('./scripts/rss-topics.js'); await fetchRssTopics();
 
-import Parser from 'rss-parser';
-import lodash from 'lodash';
-import { fileURLToPath } from 'node:url';
+const RSSParser = require('rss-parser');
+const _ = require('lodash');
 
-const { merge, orderBy } = lodash;
+const DEFAULT_FEEDS = [
+  "https://www.lemonde.fr/rss/une.xml",
+  "https://www.lefigaro.fr/rss/figaro_actualites.xml",
+  "https://www.liberation.fr/rss/latest/",
+  "https://www.leparisien.fr/une/feed/",
+  "https://www.reuters.com/rssFeed/topNews",
+  "https://www.france24.com/fr/rss",
+  "https://feeds.bbci.co.uk/news/rss.xml",
+  "https://www.euronews.com/rss?level=themes",
+  "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
+  "https://news.google.com/rss?hl=fr&gl=FR&ceid=FR:fr"
+];
+
+const parser = new RSSParser({ timeout: 15000 });
 
 const STOPWORDS = new Set([
-  'the', 'and', 'for', 'with', 'that', 'this', 'from', 'your', 'have', 'will', 'quoi', 'pour',
-  'dans', 'les', 'des', 'une', 'avec', 'plus', 'nous', 'vous', 'mais', 'elle', 'elles', 'avoir',
-  'etre', 'sont', 'est', 'sur', 'entre', 'comme', 'leur', 'leurs', 'quand', 'aussi', 'very',
-  'into', 'over', 'under', 'sans', 'their', 'them', 'they', 'alors', 'ainsi', 'pourquoi', 'dont',
-  'chez', 'vers', 'moins', 'other', 'others', 'tout', 'tous', 'toutes', 'every', 'each', 'news'
+  "les","des","les","pour","avec","dans","sur","par","une","un","le","la","et","du","de","que","qui","en","au","aux","ce","ces","se","son","sa","sont"
 ]);
 
-const GEO_WORDS = new Set([
-  'paris', 'londres', 'london', 'moscou', 'moscow', 'pekin', 'beijing', 'new york', 'berlin',
-  'madrid', 'rome', 'tokyo', 'lyon', 'marseille', 'nice', 'cannes'
-]);
-
-const POLITICS_WORDS = [
-  'président', 'president', 'ministre', 'minister', 'gouvern', 'senate', 'senator', 'politic',
-  'assembly', 'parliament', 'élysée', 'elysee', 'white house', 'elysée'
-];
-
-const CINEMA_WORDS = [
-  'film', 'films', 'réalisateur', 'realisateur', 'director', 'festival', 'cinéma', 'cinema',
-  'palme', 'cannes', 'acteur', 'actrice', 'movie', 'hollywood'
-];
-
-function extractCandidates(text) {
-  const candidates = [];
-  if (!text) {
-    return candidates;
-  }
-
-  const hashtags = text.match(/#[\p{L}0-9_]+/gu) || [];
-  hashtags.forEach((tag) => {
-    candidates.push(tag.trim());
-  });
-
-  const properNames = text.match(/\b(?:[A-ZÀ-ÖØ-Þ][a-zà-öø-ÿ']+(?:\s+[A-ZÀ-ÖØ-Þ][a-zà-öø-ÿ']+)*)/gu) || [];
-  properNames.forEach((name) => {
-    candidates.push(name.trim());
-  });
-
-  const cleaned = text
-    .replace(/[^\p{L}0-9#\s]/gu, ' ')
-    .split(/\s+/)
-    .filter(Boolean);
-
-  cleaned.forEach((word) => {
-    if (word.length > 3) {
-      candidates.push(word.trim());
-    }
-  });
-
-  return candidates;
+function norm(s){
+  return s.replace(/[^\p{L}\p{N}#\s'-]/gu, '').trim();
 }
 
-function normalizeCandidate(candidate) {
-  return candidate
-    .normalize('NFD')
-    .replace(/\p{Diacritic}/gu, '')
-    .toLowerCase();
+function extractCandidates(text){
+  if(!text) return [];
+  // hashtags
+  const hashes = [...text.matchAll(/#\w+/g)].map(m=>m[0]);
+  // capitalized sequences for names (heuristic)
+  const caps = [...text.matchAll(/([A-ZÀ-ÖØ-Ý][\p{L}'-]+(?:\s+[A-ZÀ-ÖØ-Ý][\p{L}'-]+)*)/gu)].map(m=>m[1]);
+  // words > 3 letters
+  const words = [...text.matchAll(/\b[^\d\W_]{4,}\b/gu)].map(m=>m[0]);
+  return [...hashes, ...caps, ...words].map(t=>norm(t)).filter(Boolean);
 }
 
-function isStopword(normalized) {
-  return STOPWORDS.has(normalized);
+function isLikelyPerson(token){
+  return token.split(' ').length >= 2 && /[A-ZÀ-ÖØ-Ý]/.test(token[0]);
 }
 
-function categorizeKeyword(keyword, normalized) {
-  if (/^[A-ZÀ-ÖØ-Þ][a-zà-öø-ÿ']+(?:\s+[A-ZÀ-ÖØ-Þ][a-zà-öø-ÿ']+)+$/.test(keyword)) {
-    return 'people';
-  }
-
-  if (POLITICS_WORDS.some((word) => normalized.includes(word))) {
-    return 'politics';
-  }
-
-  if (CINEMA_WORDS.some((word) => normalized.includes(word))) {
-    return 'cinema';
-  }
-
-  if (
-    GEO_WORDS.has(normalized) ||
-    /\b(paris|moscou|moscow|cannes|lyon|marseille|rome|tokyo|berlin|madrid|nice|france|italy|spain|china)\b/.test(
-      normalized
-    )
-  ) {
-    return 'geo';
-  }
-
-  return 'other';
+function assignCategory(keyword){
+  const low = keyword.toLowerCase();
+  if (isLikelyPerson(keyword)) return 'people';
+  if (/\b(president|président|ministre|gouvern|élection|déput|senat|macron|villepin|hollande|le pen|lepen)\b/i.test(low)) return 'politique';
+  if (/\b(film|cinema|festival|palme|cannes|réalisateur|acteur|actrice)\b/i.test(low)) return 'cinema';
+  if (/\b(paris|london|moscou|beijing|seoul|usa|france|russia|china|uk|onu)\b/i.test(low)) return 'geo';
+  if (low.length<=4) return 'absurde';
+  return 'absurde';
 }
 
-export async function fetchRssTopics({ feedUrls, maxPerFeed = 20 }) {
-  const parser = new Parser();
-  const aggregated = new Map();
+async function fetchFeedItems(url, maxPerFeed){
+  try{
+    const feed = await parser.parseURL(url);
+    const items = (feed.items || []).slice(0, maxPerFeed);
+    return items.map(i => ({ title: i.title||'', content: (i.contentSnippet||i.content||i.summary||'') }));
+  }catch(e){
+    // silent fallback, return empty list
+    return [];
+  }
+}
 
-  for (const feedUrl of feedUrls.filter(Boolean)) {
-    try {
-      const feed = await parser.parseURL(feedUrl);
-      const sourceLabel = feed.title || feedUrl;
-      const items = (feed.items || []).slice(0, maxPerFeed);
+async function fetchRssTopics({ feedUrls = DEFAULT_FEEDS, maxPerFeed = 20 } = {}){
+  const candidates = {};
+  const sourcesMap = {};
 
-      items.forEach((item) => {
-        const text = [
-          item.title,
-          item.contentSnippet,
-          item.content,
-          item.summary,
-          item.description,
-        ]
-          .filter(Boolean)
-          .join(' ');
-
-        const candidates = extractCandidates(text);
-        const seenInItem = new Set();
-
-        candidates.forEach((candidate) => {
-          const normalized = normalizeCandidate(candidate);
-
-          if (!normalized || isStopword(normalized)) {
-            return;
-          }
-
-          const key = normalized;
-          const entry = aggregated.get(key) || {
-            keyword: candidate,
-            normalized,
-            occurrences: 0,
-            sources: new Set(),
-          };
-
-          entry.occurrences += 1;
-
-          if (!seenInItem.has(key)) {
-            entry.sources.add(sourceLabel);
-            seenInItem.add(key);
-          }
-
-          if (entry.keyword.length < candidate.length) {
-            entry.keyword = candidate;
-          }
-
-          aggregated.set(key, entry);
-        });
-      });
-    } catch (error) {
-      console.warn(`Unable to parse feed ${feedUrl}:`, error.message);
+  for(const url of feedUrls){
+    if(!url) continue;
+    const items = await fetchFeedItems(url, maxPerFeed);
+    for(const it of items){
+      const combined = `${it.title} ${it.content}`.replace(/\s+/g,' ');
+      const tokens = extractCandidates(combined);
+      for(const t of tokens){
+        const normalized = t.toLowerCase();
+        if(STOPWORDS.has(normalized)) continue;
+        if(!candidates[normalized]) candidates[normalized] = { keyword: t, normalized, occurrences: 0, sources: new Set() };
+        candidates[normalized].occurrences += 1;
+        candidates[normalized].sources.add(url);
+      }
     }
   }
 
-  const baseCategories = {
-    people: [],
-    politics: [],
-    cinema: [],
-    geo: [],
-    other: [],
-  };
+  // build list
+  const list = Object.values(candidates).map(o => ({
+    keyword: o.keyword,
+    normalized: o.normalized,
+    occurrences: o.occurrences,
+    sources: Array.from(o.sources),
+    score: o.occurrences * Math.log(1 + o.sources.size)
+  }));
 
-  const results = Array.from(aggregated.values()).map((entry) => {
-    const sourcesArray = Array.from(entry.sources);
-    const score = entry.occurrences * Math.log(1 + sourcesArray.length);
-    const category = categorizeKeyword(entry.keyword, entry.normalized);
+  const sorted = _.orderBy(list, ['score','occurrences'], ['desc','desc']).slice(0, 200);
 
-    return {
-      keyword: entry.keyword,
-      normalized: entry.normalized,
-      occurrences: entry.occurrences,
-      sources: sourcesArray,
-      score,
-      category,
-    };
-  });
+  // topByCategory heuristic
+  const topByCategory = { politique: null, people: null, cinema: null, absurde: null, geo: null };
+  const assigned = {};
 
-  const sorted = orderBy(results, ['score', 'occurrences'], ['desc', 'desc']);
-  const top = sorted.slice(0, 10);
+  for(const item of sorted){
+    const cat = assignCategory(item.keyword);
+    if(!topByCategory[cat]) topByCategory[cat] = item.keyword;
+    assigned[item.keyword] = cat;
+  }
 
-  const topByCategory = merge({}, baseCategories);
-  sorted.forEach((item) => {
-    if (topByCategory[item.category].length < 5) {
-      topByCategory[item.category].push(item);
-    }
-  });
-
-  return {
-    date: new Date().toISOString().slice(0, 10),
+  const result = {
+    date: new Date().toISOString().slice(0,10),
     all: sorted,
-    top,
-    topByCategory,
+    top: sorted.slice(0,10),
+    topByCategory
   };
+
+  return result;
 }
 
-const __filename = fileURLToPath(import.meta.url);
-
-if (process.argv[1] && process.argv[1] === __filename) {
-  // Pour ajouter ou modifier des flux, mettez à jour ce tableau DEFAULT_FEEDS.
-  const DEFAULT_FEEDS = [
-    'https://www.lemonde.fr/rss/une.xml',
-    'https://rss.nytimes.com/services/xml/rss/nyt/World.xml',
-    'https://feeds.bbci.co.uk/news/world/rss.xml',
-    'https://www.france24.com/fr/rss',
-    'https://www.lefigaro.fr/rss/figaro_international.xml',
-    'https://www.theguardian.com/world/rss',
-    'https://www.politico.eu/feed',
-    'https://www.hollywoodreporter.com/t/rss',
-    'https://variety.com/feed/',
-    'https://www.latimes.com/world/rss2',
-  ];
-
-  fetchRssTopics({ feedUrls: DEFAULT_FEEDS })
-    .then((result) => {
-      console.log(JSON.stringify(result, null, 2));
-      // Pour tester localement : node scripts/rss-topics.js
-      // En production, exécuter ce script via une API ou un cron, puis stocker le résultat dans un KV store.
-    })
-    .catch((error) => {
-      console.error('Failed to fetch RSS topics:', error);
-      process.exitCode = 1;
-    });
+// CLI runner
+if (require.main === module) {
+  (async () => {
+    try{
+      const res = await fetchRssTopics({});
+      console.log(JSON.stringify(res, null, 2));
+    }catch(e){
+      console.error(e);
+      process.exit(1);
+    }
+  })();
 }
+
+module.exports = { fetchRssTopics };
+


### PR DESCRIPTION
## Summary
- rewrite the RSS topics script as a CommonJS module with default feed URLs and extraction helpers
- include candidate extraction, scoring, and category heuristics along with a CLI runner

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dac1e12d4c8322a6fddf51d983f070