### PR TITLE
Update RSS topics script with detailed logging and fetch handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@upstash/redis": "^1.35.4",
         "@vercel/kv": "^1.0.1",
         "lodash": "^4.17.21",
+        "node-fetch": "^2.7.0",
         "openai": "^4.57.0",
         "rss-parser": "^3.13.0"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "daily-poem",
   "version": "1.0.0",
   "private": true,
-  "type": "module",
   "scripts": {
     "format": "prettier -w ."
   },
@@ -10,6 +9,7 @@
     "@upstash/redis": "^1.35.4",
     "@vercel/kv": "^1.0.1",
     "lodash": "^4.17.21",
+    "node-fetch": "^2.7.0",
     "openai": "^4.57.0",
     "rss-parser": "^3.13.0"
   },


### PR DESCRIPTION
## Summary
- replace the RSS topics script with a CommonJS implementation that logs fetch, parse, and scoring details
- update dependencies to include node-fetch@2 and adjust the package to run the script via require

## Testing
- node scripts/rss-topics.js

------
https://chatgpt.com/codex/tasks/task_e_68dac57e588c8322a940f1024319f882