### PR TITLE
Add RSS topics API endpoints

### DIFF
--- a/api/rss-topics.js
+++ b/api/rss-topics.js
@@ -1,0 +1,54 @@
+import { fetchRssTopics } from "../scripts/rss-topics.js";
+
+function parseInteger(value, defaultValue) {
+  if (typeof value !== "string") {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    return defaultValue;
+  }
+
+  return parsed;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "method_not_allowed" });
+  }
+
+  const { feeds, limit, debug } = req.query;
+
+  const feedUrls = Array.isArray(feeds)
+    ? feeds
+    : typeof feeds === "string" && feeds
+    ? feeds.split(",").map((item) => item.trim()).filter(Boolean)
+    : undefined;
+
+  const maxPerFeed = parseInteger(req.query.maxPerFeed, undefined);
+  const topLimit = parseInteger(limit, 10);
+
+  try {
+    const result = await fetchRssTopics({
+      feedUrls,
+      maxPerFeed: Number.isInteger(maxPerFeed) ? Math.max(1, maxPerFeed) : undefined,
+    });
+
+    return res.status(200).json({
+      date: result.date,
+      top: Array.isArray(result.top)
+        ? result.top.slice(0, Number.isInteger(topLimit) ? Math.max(1, topLimit) : 10)
+        : [],
+      topByCategory: result.topByCategory,
+      all: debug === "1" || debug === "true" ? result.all : undefined,
+      feedDebug: debug === "1" || debug === "true" ? result.feedDebug : undefined,
+    });
+  } catch (error) {
+    console.error("/api/rss-topics", error);
+    return res
+      .status(500)
+      .json({ error: "internal_error", message: "failed_to_fetch_rss_topics" });
+  }
+}

--- a/pages/api/rss-topics.ts
+++ b/pages/api/rss-topics.ts
@@ -1,0 +1,97 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { fetchRssTopics } from "../../scripts/rss-topics.js";
+
+type RssTopicsResponse =
+  | {
+      date: string;
+      top: Array<{
+        keyword: string;
+        normalized: string;
+        occurrences: number;
+        sources: string[];
+        score: number;
+      }>;
+      topByCategory: Record<string, string | null>;
+      all?: Array<{
+        keyword: string;
+        normalized: string;
+        occurrences: number;
+        sources: string[];
+        score: number;
+      }>;
+      feedDebug?: unknown;
+    }
+  | { error: string; message?: string };
+
+function parseInteger(value: string | string[] | undefined, defaultValue: number | undefined) {
+  if (!value || Array.isArray(value)) {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+function parseFeeds(feeds: string | string[] | undefined): string[] | undefined {
+  if (!feeds) {
+    return undefined;
+  }
+
+  if (Array.isArray(feeds)) {
+    const list = feeds.map((item) => item.trim()).filter(Boolean);
+    return list.length > 0 ? list : undefined;
+  }
+
+  const list = feeds
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  return list.length > 0 ? list : undefined;
+}
+
+function shouldIncludeDebug(flag: string | string[] | undefined): boolean {
+  if (Array.isArray(flag)) {
+    return flag.some((value) => shouldIncludeDebug(value));
+  }
+
+  return flag === "1" || flag === "true";
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<RssTopicsResponse>
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "method_not_allowed" });
+  }
+
+  try {
+    const feedUrls = parseFeeds(req.query.feeds);
+    const maxPerFeed = parseInteger(req.query.maxPerFeed, undefined);
+    const limit = parseInteger(req.query.limit, 10);
+    const debug = shouldIncludeDebug(req.query.debug);
+
+    const result = await fetchRssTopics({
+      feedUrls,
+      maxPerFeed: Number.isInteger(maxPerFeed) ? Math.max(1, maxPerFeed) : undefined,
+    });
+
+    const topLimit = Number.isInteger(limit) ? Math.max(1, limit) : 10;
+    const top = Array.isArray(result.top) ? result.top.slice(0, topLimit) : [];
+
+    return res.status(200).json({
+      date: result.date,
+      top,
+      topByCategory: result.topByCategory,
+      all: debug ? result.all : undefined,
+      feedDebug: debug ? result.feedDebug : undefined,
+    });
+  } catch (error) {
+    console.error("/pages/api/rss-topics", error);
+    return res
+      .status(500)
+      .json({ error: "internal_error", message: "failed_to_fetch_rss_topics" });
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,8 @@
   "rewrites": [
     { "source": "/api/poem", "destination": "/api/today.js" },
     { "source": "/api/today", "destination": "/api/today.js" },
-    { "source": "/api/cron-generate", "destination": "/api/cron-generate.js" }
+    { "source": "/api/cron-generate", "destination": "/api/cron-generate.js" },
+    { "source": "/api/rss-topics", "destination": "/api/rss-topics.js" }
   ],
   "crons": [
     { "path": "/api/cron-generate", "schedule": "0 13 * * *" }


### PR DESCRIPTION
## Summary
- add serverless handler that exposes RSS topics extraction with filtering options
- mirror the handler in Next.js API routes for local development compatibility
- update Vercel rewrites to surface the new endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad4a088088322babd2e45417b33ce