### PR TITLE
fix: update Vercel cron schedule

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,23 @@
 {
   "cleanUrls": true,
   "rewrites": [
-    { "source": "/api/today", "destination": "/api/today.js" },
-    { "source": "/api/cron-generate", "destination": "/api/cron-generate.js" },
-    { "source": "/api/rss-topics", "destination": "/api/rss-topics.js" }
+    {
+      "source": "/api/today",
+      "destination": "/api/today.js"
+    },
+    {
+      "source": "/api/cron-generate",
+      "destination": "/api/cron-generate.js"
+    },
+    {
+      "source": "/api/rss-topics",
+      "destination": "/api/rss-topics.js"
+    }
   ],
   "crons": [
-    { "path": "/api/cron-generate", "schedule": "0 13 * * *" }
+    {
+      "path": "/api/daily-rotate",
+      "schedule": "0 14 * * *"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- replace the existing Vercel cron with a single /api/daily-rotate job
- schedule the cron for 14:00 UTC to stay within the free Vercel plan limits

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae62cd6e08322b4fcaaa0dfbf55b9