### PR TITLE
Add rewrite for /api/daily-rotate cron endpoint

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,10 @@
       "destination": "/api/cron-generate.js"
     },
     {
+      "source": "/api/daily-rotate",
+      "destination": "/api/daily-rotate.js"
+    },
+    {
       "source": "/api/rss-topics",
       "destination": "/api/rss-topics.js"
     }


### PR DESCRIPTION
## Summary
- add a Vercel rewrite so the daily-rotate endpoint points at the compiled serverless function

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dae86533388322836135ad1bbc4613