### PR TITLE
chore: simplify cron jobs to stay within free Vercel quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Déployable sur **Vercel**.
 
 - API publique: `/api/today`  (lit KV)
-- Cron Vercel: `/api/cron-generate`  (protégé; génère 1×/jour à 13:00 UTC)
+- Cron Vercel: `/api/daily-rotate` (protégé; déclenche 1×/jour à 14:00 UTC pour garantir la génération à 15h/16h Paris)
 - Stockage: Vercel KV, clé `poem:YYYY-MM-DD`
 
 ## Variables d'environnement


### PR DESCRIPTION
## Summary
- update the README to document the single 14:00 UTC cron hitting `/api/daily-rotate`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae9af8cb883229057bc517f690da9