### PR TITLE
Affiche le dernier poème lorsqu’aucun nouveau n’est disponible

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,110 @@
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Poème du jour</title><link rel="stylesheet" href="/styles.css"/>
 </head><body><main class="wrap">
-<h1>Poème du jour</h1><p class="date" id="date"></p><pre id="poem">Chargement…</pre><p class="hashtags" id="tags"></p>
+<h1>Poème du jour</h1>
+<p class="date" id="date"></p>
+<p class="notice hidden" id="status"></p>
+<pre id="poem">Chargement…</pre>
+<p class="hashtags" id="tags"></p>
 </main><script>
-(async()=>{try{
-  const r=await fetch('/api/today'); const data=await r.json();
-  if(!r.ok) throw new Error(data?.message||'not ready');
-  date.textContent=data.date; poem.textContent=data.poem; tags.textContent='Hashtags: '+data.hashtags.join(' ');
-  }catch(e){poem.textContent='Le poème sera publié à 15h (heure de Paris).'; tags.textContent='';}})
-();
+(function(){
+  const STORAGE_KEY='poeme-du-jour:last';
+  const WAITING_MESSAGE='Le poème sera publié à 15h (heure de Paris).';
+
+  const dateEl=document.getElementById('date');
+  const poemEl=document.getElementById('poem');
+  const tagsEl=document.getElementById('tags');
+  const statusEl=document.getElementById('status');
+
+  if(!dateEl||!poemEl||!tagsEl||!statusEl){
+    return;
+  }
+
+  function showStatus(text){
+    if(text&&text.trim()){
+      statusEl.textContent=text;
+      statusEl.classList.remove('hidden');
+    }else{
+      statusEl.textContent='';
+      statusEl.classList.add('hidden');
+    }
+  }
+
+  function normaliseHashtags(input){
+    if(!Array.isArray(input)) return [];
+    return input
+      .map((tag)=>typeof tag==='string'?tag.trim(): '')
+      .filter(Boolean);
+  }
+
+  function renderPoem(data,source){
+    const hashtags=normaliseHashtags(data.hashtags);
+    dateEl.textContent=typeof data.date==='string'?data.date:'';
+    poemEl.textContent=typeof data.poem==='string'?data.poem:WAITING_MESSAGE;
+    tagsEl.textContent=hashtags.length?'Hashtags: '+hashtags.join(' '):'';
+
+    const noteRaw=typeof data.note==='string'?data.note:'';
+    const fallbackNote='Poème précédent affiché en attendant la nouvelle publication.';
+    const note=noteRaw|| (source==='cache'?fallbackNote:'');
+    showStatus(note);
+  }
+
+  function readCache(){
+    try{
+      const raw=window.localStorage.getItem(STORAGE_KEY);
+      if(!raw) return null;
+      const parsed=JSON.parse(raw);
+      if(!parsed||typeof parsed.poem!=='string') return null;
+      return{
+        date:typeof parsed.date==='string'?parsed.date:'',
+        poem:parsed.poem,
+        hashtags:normaliseHashtags(parsed.hashtags),
+        note:typeof parsed.note==='string'?parsed.note:'',
+        generatedAt:typeof parsed.generatedAt==='string'?parsed.generatedAt:undefined,
+      };
+    }catch(_err){
+      return null;
+    }
+  }
+
+  function writeCache(data){
+    try{
+      const payload={
+        date:typeof data.date==='string'?data.date:'',
+        poem:typeof data.poem==='string'?data.poem:'',
+        hashtags:normaliseHashtags(data.hashtags),
+        note:typeof data.note==='string'?data.note:'',
+        generatedAt:typeof data.generatedAt==='string'?data.generatedAt:undefined,
+      };
+      window.localStorage.setItem(STORAGE_KEY,JSON.stringify(payload));
+    }catch(_err){
+      // ignore storage errors
+    }
+  }
+
+  const cachedPoem=readCache();
+  if(cachedPoem){
+    renderPoem(cachedPoem,'cache');
+  }
+
+  (async()=>{
+    try{
+      const response=await fetch('/api/today');
+      const data=await response.json();
+      if(!response.ok||typeof data!=='object'||data===null||typeof data.poem!=='string'){
+        throw new Error('not_ready');
+      }
+      renderPoem(data,'network');
+      writeCache(data);
+    }catch(_error){
+      if(cachedPoem){
+        showStatus('Poème précédent affiché en attendant la nouvelle publication.');
+      }else{
+        poemEl.textContent=WAITING_MESSAGE;
+        tagsEl.textContent='';
+        showStatus('');
+      }
+    }
+  })();
+})();
 </script></body></html>

--- a/styles.css
+++ b/styles.css
@@ -2,5 +2,7 @@
 .wrap { max-width: 720px; margin: 6rem auto; padding: 0 1rem; }
 h1 { font-size: clamp(2rem, 3vw, 3rem); margin: 0 0 0.5rem; }
 .date { opacity:.7; margin: 0 0 2rem; }
+.notice { margin: 0 0 1.5rem; font-style: italic; opacity:.75; }
+.notice.hidden { display: none; }
 pre { white-space: pre-wrap; line-height: 1.6; font-size: 1.15rem; }
 .hashtags { margin-top: 1rem; opacity:.8; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }


### PR DESCRIPTION
## Summary
- ajoute un bandeau d’information sur la page d’accueil pour indiquer le statut du poème
- met en cache localement le dernier poème récupéré et l’affiche en cas d’indisponibilité de la génération du jour
- améliore l’affichage des hashtags uniquement lorsque des données sont disponibles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db71c97460832290f7bb8e77eeadad