### PR TITLE
Ensure latest poem is always displayed dynamically

### DIFF
--- a/app/api/poems/latest/route.ts
+++ b/app/api/poems/latest/route.ts
@@ -1,0 +1,83 @@
+import { kv } from "@vercel/kv";
+import { NextResponse } from "next/server";
+
+export const revalidate = 0;
+
+const CACHE_CONTROL_HEADER = { "Cache-Control": "no-store" } as const;
+const POEM_PREFIX = "poem:";
+
+interface PoemRecord {
+  html?: string;
+  publishedAt?: string;
+}
+
+async function loadPoems(): Promise<PoemRecord[]> {
+  const poems: PoemRecord[] = [];
+
+  for await (const key of kv.scanIterator({ match: `${POEM_PREFIX}*` })) {
+    if (typeof key !== "string") continue;
+    const record = await kv.get<unknown>(key);
+    if (!record) continue;
+
+    if (typeof record === "string") {
+      try {
+        const parsed = JSON.parse(record) as PoemRecord;
+        poems.push(parsed);
+      } catch (error) {
+        console.warn("Ignoring invalid JSON for", key, error);
+      }
+      continue;
+    }
+
+    if (typeof record === "object") {
+      poems.push(record as PoemRecord);
+    }
+  }
+
+  return poems;
+}
+
+function parseDate(value: string | undefined): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export async function GET() {
+  try {
+    const poems = await loadPoems();
+    const now = new Date();
+
+    const latest = poems
+      .map((poem) => ({
+        html: typeof poem.html === "string" ? poem.html : undefined,
+        publishedAt: typeof poem.publishedAt === "string" ? poem.publishedAt : undefined,
+      }))
+      .filter((poem) => poem.html && poem.publishedAt)
+      .map((poem) => ({
+        html: poem.html as string,
+        publishedAt: poem.publishedAt as string,
+        date: parseDate(poem.publishedAt),
+      }))
+      .filter((poem) => poem.date && poem.date.getTime() <= now.getTime())
+      .sort((a, b) => (a.date! < b.date! ? 1 : -1))[0] ?? null;
+
+    if (!latest) {
+      return NextResponse.json(null, {
+        status: 200,
+        headers: CACHE_CONTROL_HEADER,
+      });
+    }
+
+    return NextResponse.json(
+      { html: latest.html, publishedAt: latest.publishedAt },
+      { headers: CACHE_CONTROL_HEADER }
+    );
+  } catch (error) {
+    console.error("/api/poems/latest error", error);
+    return NextResponse.json(
+      { error: "internal_error" },
+      { status: 500, headers: CACHE_CONTROL_HEADER }
+    );
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const STORAGE_KEY = "lastPoemHtml";
+
+interface LatestPoem {
+  html: string;
+  publishedAt?: string;
+}
+
+function readCachedPoem(): LatestPoem | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return { html: raw };
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedPoem(html: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, html);
+  } catch {
+    // Ignore persistence errors (quota, privacy mode, ...)
+  }
+}
+
+export default function Page() {
+  const [poem, setPoem] = useState<LatestPoem | null>(null);
+  const [isFallback, setIsFallback] = useState(false);
+  const [empty, setEmpty] = useState(false);
+
+  useEffect(() => {
+    const cachedAtStart = readCachedPoem();
+    if (cachedAtStart) {
+      setPoem(cachedAtStart);
+      setIsFallback(true);
+    }
+
+    let cancelled = false;
+
+    const loadPoem = async () => {
+      try {
+        const response = await fetch("/api/poems/latest", {
+          cache: "no-store",
+        });
+
+        if (!response.ok) {
+          throw new Error(`fetch_failed:${response.status}`);
+        }
+
+        const payload: LatestPoem | null = await response.json();
+
+        if (cancelled) return;
+
+        if (!payload || typeof payload.html !== "string" || !payload.html.trim()) {
+          const cachedFallback = readCachedPoem();
+          setEmpty(!cachedFallback);
+          setIsFallback(Boolean(cachedFallback));
+          setPoem(cachedFallback);
+          return;
+        }
+
+        setPoem(payload);
+        setIsFallback(false);
+        setEmpty(false);
+        writeCachedPoem(payload.html);
+      } catch (error) {
+        if (cancelled) return;
+        const cachedFallback = readCachedPoem();
+        if (cachedFallback) {
+          setPoem(cachedFallback);
+          setIsFallback(true);
+          setEmpty(false);
+        } else {
+          setEmpty(true);
+          setPoem(null);
+        }
+      }
+    };
+
+    loadPoem();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const publishedAt = useMemo(() => poem?.publishedAt ?? null, [poem]);
+
+  return (
+    <main className="poem-wrapper">
+      {poem ? (
+        <article
+          className="poem"
+          dangerouslySetInnerHTML={{ __html: poem.html }}
+        />
+      ) : null}
+
+      {!poem && empty ? (
+        <p className="empty">Pas encore de poème disponible.</p>
+      ) : null}
+
+      {poem && isFallback ? (
+        <p className="fallback-note">
+          Affichage du dernier poème disponible en attendant la prochaine
+          publication.
+        </p>
+      ) : null}
+
+      {publishedAt ? (
+        <p className="published-at">Publié le {publishedAt}</p>
+      ) : null}
+    </main>
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -18,6 +18,26 @@
       "destination": "/api/rss-topics.js"
     }
   ],
+  "headers": [
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store"
+        }
+      ]
+    },
+    {
+      "source": "/api/poems/latest",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store"
+        }
+      ]
+    }
+  ],
   "crons": [
     {
       "path": "/api/daily-rotate",


### PR DESCRIPTION
## Summary
- add a dynamic app router homepage that always fetches /api/poems/latest with a localStorage fallback and no waiting screen
- expose a new /api/poems/latest route that returns the most recent poem published before now with no-store caching
- configure Vercel headers to disable caching on the root page and latest-poem API endpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db756c3224832291d6d63996a2ecd6