### PR TITLE
fix: today API fallback to inaugural poem

### DIFF
--- a/app/api/today/route.ts
+++ b/app/api/today/route.ts
@@ -8,13 +8,11 @@ export async function GET() {
   if (!poem) {
     poem = {
       title: "Poème inaugural",
-      poem: [
-        "Une cigarette rougeoyait dans le soir",
-        "La sauterelle bondissait d’un mot à l’autre",
-        "Un porte-avion traversait la mémoire",
-        "Sous un parfum de nullitude",
-        "Et tout s’achevait dans une flaque de ketchup."
-      ].join("\n")
+      poem: `Une cigarette rougeoyait dans le soir
+La sauterelle bondissait d’un mot à l’autre
+Un porte-avion traversait la mémoire
+Sous un parfum de nullitude
+Et tout s’achevait dans une flaque de ketchup.`
     };
   }
 


### PR DESCRIPTION
## Summary
- ensure the today API returns a deterministic inaugural poem when no entry is stored in KV
- provide the poem text as a multiline template literal that matches the desired content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc263f70f8832297b719f0ecc6dffc