### PR TITLE
Add edge /api/ping diagnostic route

### DIFF
--- a/app/api/ping/route.ts
+++ b/app/api/ping/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+export async function GET() {
+  return NextResponse.json(
+    { ok: true, msg: "pong" },
+    {
+      headers: { "Cache-Control": "no-store" }
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add a ping API endpoint that responds with `{ ok: true, msg: "pong" }`
- configure the endpoint to run on the edge runtime and disable caching

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2ba752cc8322a3ed748ea7e97ff6