### PR TITLE
Ensure cron only publishes once daily at 15h Paris time

### DIFF
--- a/app/api/cron/generate/route.ts
+++ b/app/api/cron/generate/route.ts
@@ -1,16 +1,41 @@
 import { NextResponse } from 'next/server';
 import { utcToZonedTime, format } from 'date-fns-tz';
 
-import { createPoemHTML, savePoem, pickCity } from '../../../../lib/poems';
+import {
+  createPoemHTML,
+  savePoem,
+  pickCity,
+  parisDateId,
+  poemExistsForParisDate,
+} from '@/lib/poems';
 
 export const revalidate = 0;
 
 export async function GET() {
-  const parisNow = utcToZonedTime(new Date(), 'Europe/Paris');
+  const now = new Date();
+  const parisNow = utcToZonedTime(now, 'Europe/Paris');
+  const hourParis = Number(format(parisNow, 'H', { timeZone: 'Europe/Paris' }));
+
+  if (hourParis !== 15) {
+    return NextResponse.json(
+      { ok: true, skipped: true, reason: 'not 15h Paris' },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  const dayId = parisDateId(parisNow);
+  if (await poemExistsForParisDate(dayId)) {
+    return NextResponse.json(
+      { ok: true, skipped: true, reason: 'already generated today' },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+
   const publishedAt = format(parisNow, "yyyy-MM-dd'T'HH:mm:ssXXX", { timeZone: 'Europe/Paris' });
   const city = await pickCity();
   const html = await createPoemHTML(city);
   const poem = { id: crypto.randomUUID(), city, html, publishedAt };
   await savePoem(poem);
-  return NextResponse.json({ ok: true, poem }, { headers: { 'Cache-Control': 'no-store' } });
+
+  return NextResponse.json({ ok: true, created: poem }, { headers: { 'Cache-Control': 'no-store' } });
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "crons": [
-    { "path": "/api/cron/generate", "schedule": "0 15 * * *", "timeZone": "Europe/Paris" }
+    { "path": "/api/cron/generate", "schedule": "0 * * * *" }
   ]
 }


### PR DESCRIPTION
## Summary
- run the Vercel cron hourly in UTC so the handler controls publication timing
- add Paris timezone helpers to identify existing poems for the current day
- update the cron route to skip runs until 15h Paris and avoid duplicate daily poems

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de131ac220832283ea15d6ba999555