### PR TITLE
Configure Vercel build and cron settings

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
+  "buildCommand": "next build",
+  "outputDirectory": ".next",
   "crons": [
-    { "path": "/api/cron/generate", "schedule": "10 0 * * *" }
+    {
+      "path": "/api/cron/generate",
+      "schedule": "10 0 * * *"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- update `vercel.json` to run `next build` and output to `.next`
- schedule the `/api/cron/generate` endpoint to run daily at 00:10 UTC

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de1c36854c8322803c7b8e2f9f6f44