### PR TITLE
Ensure Vercel uses Next.js build output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Assurez-vous de configurer Vercel KV (intégration native ou variables suivantes
 2. Configurez l'intégration **Vercel KV** ou définissez les variables d'environnement listées ci-dessus.
 3. Poussez vos changements sur la branche `main` pour déclencher un déploiement.
 
+### Paramètres Vercel
+
+- Vercel Settings → Build & Output: **ne définissez pas** de champ "Output Directory". Laissez le `vercel.json` du dépôt piloter le build.
+- Si un override "Output Directory" est activé dans le tableau de bord, désactivez-le ou laissez le champ vide.
+
 ## Cron
 
 Le fichier `vercel.json` déclare un cron Vercel appelant `/api/cron/generate` chaque jour à 15:00 (Europe/Paris).


### PR DESCRIPTION
## Summary
- document Vercel dashboard settings so the deployment relies on the repo's vercel.json configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de20c86e388322b46d0a72ec224153