### PR TITLE
fix: clean vercel.json (keep only cron) + trigger redeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,6 @@ Le fichier `vercel.json` déclare un cron Vercel appelant `/api/cron/generate` c
 1. Installez les dépendances : `npm install`.
 2. Démarrez le serveur : `npm run dev`.
 3. Définissez des variables KV locales (Upstash/Vercel KV) pour tester la persistance.
+
+
+🚀 Trigger redeploy at Thu Oct  2 11:12:05 UTC 2025


### PR DESCRIPTION
## Summary
- add a redeploy trigger entry to the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5c5f849c83229fe1f03112b632ae