### PR TITLE
Add health and manual poem generation endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ Le fichier `vercel.json` déclare un cron Vercel appelant `/api/cron/generate` c
 
 
 ✅ Reset Vercel config at 2025-10-02T12:14:19Z
+
+
+✅ Added /api/health and /api/manual-generate at 2025-10-02T12:22:00Z

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,12 +1,10 @@
-import { NextResponse } from 'next/server';
+import { NextResponse } from "next/server";
 
 export const revalidate = 0;
 
 export async function GET() {
   return NextResponse.json(
-    { ok: true, service: 'daily-poem', ts: new Date().toISOString() },
-    {
-      headers: { 'Cache-Control': 'no-store' }
-    }
+    { ok: true, service: "daily-poem", ts: new Date().toISOString() },
+    { headers: { "Cache-Control": "no-store" } }
   );
 }

--- a/app/api/manual-generate/route.ts
+++ b/app/api/manual-generate/route.ts
@@ -1,40 +1,72 @@
-import { NextResponse } from 'next/server';
-import { utcToZonedTime, format } from 'date-fns-tz';
-import crypto from 'crypto';
-import { pickCity, createPoemHTML, savePoem, parisDateId, poemExistsForParisDate } from '@/lib/poems';
+import { NextResponse } from "next/server";
+import { utcToZonedTime, format } from "date-fns-tz";
+import crypto from "crypto";
+import {
+  pickCity,
+  createPoemHTML,
+  savePoem,
+  parisDateId,
+  poemExistsForParisDate,
+} from "@/lib/poems";
 
 export const revalidate = 0;
 
 export async function GET(req: Request) {
-  const url = new URL(req.url);
-  const visible = url.searchParams.get('visible') === '1';
-  const force = url.searchParams.get('force') === '1';
-  const cityParam = url.searchParams.get('city');
+  try {
+    const url = new URL(req.url);
+    const visible = url.searchParams.get("visible") === "1";
+    const force = url.searchParams.get("force") === "1";
+    const forcedCity = url.searchParams.get("city")?.trim();
 
-  const now = new Date();
-  const parisNow = utcToZonedTime(now, 'Europe/Paris');
-  const dayId = parisDateId(parisNow);
+    const now = new Date();
+    const parisNow = utcToZonedTime(now, "Europe/Paris");
+    const dayId = parisDateId(parisNow);
 
-  if (!force && await poemExistsForParisDate(dayId)) {
+    if (!force && (await poemExistsForParisDate(dayId))) {
+      return NextResponse.json(
+        { ok: true, skipped: true, reason: "already generated today" },
+        { headers: { "Cache-Control": "no-store" } }
+      );
+    }
+
+    // Choix de l’horodatage publishedAt
+    let publishedAt: string;
+    if (visible) {
+      // visible immédiatement
+      const visibleParis = new Date(parisNow.getTime() - 1000);
+      publishedAt = format(visibleParis, "yyyy-MM-dd'T'HH:mm:ssXXX", {
+        timeZone: "Europe/Paris",
+      });
+    } else {
+      // publication à 15:00 Paris aujourd’hui
+      const fifteen = new Date(parisNow);
+      fifteen.setHours(15, 0, 0, 0);
+      publishedAt = format(fifteen, "yyyy-MM-dd'T'HH:mm:ssXXX", {
+        timeZone: "Europe/Paris",
+      });
+    }
+
+    const city = forcedCity && forcedCity.length > 0 ? forcedCity : await pickCity();
+    const html = await createPoemHTML(city);
+
+    const poem = {
+      id: crypto.randomUUID(),
+      city,
+      html,
+      publishedAt,
+    };
+
+    await savePoem(poem);
+
     return NextResponse.json(
-      { ok: true, skipped: true, reason: 'already generated today' },
-      { headers: { 'Cache-Control': 'no-store' } }
+      { ok: true, created: poem },
+      { headers: { "Cache-Control": "no-store" } }
+    );
+  } catch (err) {
+    console.error("[manual-generate] error:", err);
+    return NextResponse.json(
+      { ok: false, error: "internal_error" },
+      { status: 200, headers: { "Cache-Control": "no-store" } }
     );
   }
-
-  let publishedAt: string;
-  if (visible) {
-    const visibleParis = new Date(parisNow.getTime() - 1000);
-    publishedAt = format(visibleParis, "yyyy-MM-dd'T'HH:mm:ssXXX", { timeZone: 'Europe/Paris' });
-  } else {
-    const fifteen = new Date(parisNow);
-    fifteen.setHours(15, 0, 0, 0);
-    publishedAt = format(fifteen, "yyyy-MM-dd'T'HH:mm:ssXXX", { timeZone: 'Europe/Paris' });
-  }
-
-  const city = cityParam?.trim() || await pickCity();
-  const html = await createPoemHTML(city);
-  const poem = { id: crypto.randomUUID(), city, html, publishedAt };
-  await savePoem(poem);
-  return NextResponse.json({ ok: true, created: poem }, { headers: { 'Cache-Control': 'no-store' } });
 }

--- a/app/api/poems/latest/route.ts
+++ b/app/api/poems/latest/route.ts
@@ -1,9 +1,26 @@
-import { NextResponse } from 'next/server';
-import { getLatestPoemBefore } from '@/lib/poems';
+import { NextResponse } from "next/server";
+import { getLatestPoemBefore } from "@/lib/poems";
 
 export const revalidate = 0;
 
 export async function GET() {
-  const poem = await getLatestPoemBefore(new Date());
-  return NextResponse.json(poem, { headers: { 'Cache-Control': 'no-store' } });
+  try {
+    const now = new Date();
+    const poem = await getLatestPoemBefore(now);
+    console.log(
+      "[latest] now=%s, hasPoem=%s, publishedAt=%s",
+      now.toISOString(),
+      !!poem,
+      poem?.publishedAt ?? null
+    );
+    return NextResponse.json(poem ?? null, {
+      headers: { "Cache-Control": "no-store" },
+    });
+  } catch (err) {
+    console.error("[latest] error:", err);
+    return NextResponse.json(null, {
+      status: 200,
+      headers: { "Cache-Control": "no-store" },
+    });
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,15 +2,16 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 export default async function Home() {
-  const res = await fetch('/api/poems/latest', { cache: 'no-store' });
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ''}/api/poems/latest`, { cache: 'no-store' });
   const poem = res.ok ? await res.json() : null;
+
   return (
-    <main style={{maxWidth:720, margin:'64px auto', padding:24}}>
-      <h1 style={{fontSize:42, marginBottom:24}}>Poème du jour</h1>
+    <main style={{ maxWidth: 720, margin: '64px auto', padding: 24 }}>
+      <h1 style={{ fontSize: 42, marginBottom: 24 }}>Poème du jour</h1>
       {poem?.html ? (
         <article dangerouslySetInnerHTML={{ __html: poem.html }} />
       ) : (
-        <p style={{opacity:.7}}>Pas encore de poème disponible.</p>
+        <p style={{ opacity: .7 }}>Pas encore de poème disponible.</p>
       )}
     </main>
   );


### PR DESCRIPTION
## Summary
- add a health check endpoint for uptime monitoring
- allow manual poem generation with visibility and force options
- harden latest poem API responses and ensure the home page uses dynamic fetches
- append a deployment log entry to the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6e2b1c288322b1322ec8adcbcff1