### PR TITLE
Add manual poem generation endpoint

### DIFF
--- a/app/api/manual-generate/route.ts
+++ b/app/api/manual-generate/route.ts
@@ -40,8 +40,7 @@ export async function GET(req: Request) {
       });
     }
 
-    const city =
-      forcedCity && forcedCity.length > 0 ? forcedCity : await pickCity();
+    const city = forcedCity && forcedCity.length > 0 ? forcedCity : await pickCity();
     const html = await createPoemHTML(city);
 
     const poem = {


### PR DESCRIPTION
## Summary
- add a manual-generate API route that respects existing poem generation helpers
- ensure publishedAt timestamps align with visibility and scheduling rules

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de70c393c08322875d9232dbdff513