### PR TITLE
chore: enforce Next.js preset for Vercel

### DIFF
--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,0 +1,5 @@
+{
+  "settings": {
+    "framework": "nextjs"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -63,3 +63,5 @@ Le fichier `vercel.json` déclare un cron Vercel appelant `/api/cron/generate` c
 ✅ fix 404: add app/layout.tsx + SSR home 2025-10-02T12:51:08Z
 
 ✅ repair: layout/page/api written 2025-10-02T12:59:04Z
+
+🔧 enforce Next.js preset via .vercel/project.json @ 2025-10-02T13:07:35Z


### PR DESCRIPTION
## Summary
- add `.vercel/project.json` so Vercel uses the Next.js preset automatically
- append deployment note to the README to trigger a redeploy

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68de78eeda7c8322a015fba41263edc8